### PR TITLE
Bug in check_ble_set

### DIFF
--- a/main/badge/badge.c
+++ b/main/badge/badge.c
@@ -23,7 +23,7 @@ bool check_ble_set()
     for(int i=0; i<MAX_NEARBY_NODE; i++)
     {
         if(ble_nodes[i].active){
-            set_bits |= 1 << (ble_nodes->id-1);
+            set_bits |= 1 << (ble_nodes[i].id-1);
         }
     }
     return set_bits == 0x7F;


### PR DESCRIPTION
the check for the 7 spheres always fail because only check the first ble device id every loop (ble_nodes->id instead of ble_nodes[i].id).