### PR TITLE
Fix ESP-IDF platform version

### DIFF
--- a/main/badge/badge.c
+++ b/main/badge/badge.c
@@ -94,7 +94,7 @@ const char* json_get_str_value(cJSON* obj, const char *key)
 int json_get_int_value(cJSON* obj, const char *key)
 {
     int value = cJSON_GetObjectItem(obj, key)->valueint;
-    ESP_LOGI(__FILE__, "Get %s value %s", key, value);
+    ESP_LOGI(__FILE__, "Get %s value %d", key, value);
     return value;
 }
 

--- a/main/badge/badge.h
+++ b/main/badge/badge.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include "esp_log.h"
+#include "esp_mac.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ src_dir = main
 data_dir = data
 
 [env:rhc22-badge]
-platform = espressif32
+platform = espressif32 @ 5.4.0
 board = esp32-c3-devkitm-1
 framework = espidf
 board_build.partitions = partitions.csv


### PR DESCRIPTION
Latest Espressif Development Kit version does not compile with current codebase; it needs to set "platform" version to use in Platformio.