### PR TITLE
Correct prefixing sound of FREKETE

### DIFF
--- a/data/default.json
+++ b/data/default.json
@@ -11,6 +11,6 @@
     },
     "sta": {
         "ssid": "CyberSaiyan-MOCA2024",
-        "password": "eFREKETE"
+        "password": "oFREKETE"
     }
 }


### PR DESCRIPTION
In the Abruzzese dialect the prefixing sound often emitted before the "freghete" (or, hardened, "frekete") exclamation is the Short-o-2 (aka Alternate-Short-o). To pronounce this sound clearly, the lips should NOT be rounded, the tongue should be very relaxed in the middle of the mouth, and the mouth is less open than for regular Short-o. Its emission can also diverge for the Schwa sound in some cases: the prefix is not stressed, but never completely elided. The tongue does not have to go up or down, or forward, or back. It stays right in the middle and completely relaxed in the middle of the mouth, right before lips and teeth join into the fricative /f/.

All the above considered, I believe a better representation of this prefix is to use the ASCII code 0x6F 'o' instead of the misleading 0x65 'e'.